### PR TITLE
Attempting to implement LinkAce as a sharing method

### DIFF
--- a/app/i18n/en/gen.php
+++ b/app/i18n/en/gen.php
@@ -219,6 +219,7 @@ return array(
 		'gnusocial' => 'GNU social',
 		'jdh' => 'Journal du hacker',
 		'lemmy' => 'Lemmy',
+		'linkace' => 'LinkAce',
 		'linkding' => 'Linkding',
 		'linkedin' => 'LinkedIn',
 		'mastodon' => 'Mastodon',

--- a/app/shares.php
+++ b/app/shares.php
@@ -116,6 +116,25 @@ return [
 		'form' => 'advanced',
 		'method' => 'GET',
 	],
+	'linkace' => [
+    'url' => 'https://your-linkace-url.com/api/v1/links',
+    'transform' => ['rawurlencode'],
+    'help' => 'https://api-docs.linkace.org/', // Link to the API documentation
+    'form' => 'advanced',
+    'method' => 'POST',
+    'headers' => [
+        'accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'authorization' => 'Bearer zeGEaJtcVj4Em2E9sZUwaHRITcBA5XKk'
+    ],
+    'data' => [
+        'url' => '{url}', // URL of the bookmark to be added
+        'title' => '{title}', // Title of the page
+        'is_private' => false, // Optional: set to true if the link should be private
+        'tags' => [], // Optional: an array of tag IDs
+        'lists' => [] // Optional: an array of list IDs
+    ]
+	],
 	'linkding' => [
 		'url' => '~URL~/bookmarks/new?url=~LINK~&title=~TITLE~&auto_close',
 		'transform' => ['rawurlencode'],


### PR DESCRIPTION
Works on #6698

Changes proposed in this pull request:

- Added LinkAce as a sharing method in shares.php
- Added LinkAce to the english file in app/i18n to make it appear in the front end


How to test the feature manually:

1. Add LinkAce as a sharing method in your FreshRSS
2. Try to share anything using Readeck
3. It should appear in your Readeck locally

Pull request checklist:

- [ ] clear commit messages
- [ ] code manually tested
- [ ] unit tests written (optional if too hard)
- [ ] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
